### PR TITLE
Update LogHelper error type

### DIFF
--- a/src/RJP.MultiUrlPicker/MultiUrlPickerValueConverter.cs
+++ b/src/RJP.MultiUrlPicker/MultiUrlPickerValueConverter.cs
@@ -50,7 +50,7 @@ namespace RJP.MultiUrlPicker
                 }
                 catch (Exception ex)
                 {
-                    LogHelper.Error<DropdownListMultipleValueConverter>("Error parsing JSON", ex);
+                    LogHelper.Error<MultiUrlPickerValueConverter>("Error parsing JSON", ex);
                 }
             }
             return null;


### PR DESCRIPTION
Change LogHelper error type from `DropdownListMultipleValueConverter` to `MultiUrlPickerValueConverter`.